### PR TITLE
Test for local image

### DIFF
--- a/compose/.env.sample
+++ b/compose/.env.sample
@@ -1,5 +1,5 @@
 DATADIR=/data/bluespice
-VERSION=4.5
+VERSION=5.1
 EDITION=free
 BACKUP_HOUR=04
 

--- a/compose/bluespice-deploy
+++ b/compose/bluespice-deploy
@@ -23,9 +23,13 @@ export UPGRADE_ACTION=${UPGRADE_ACTION:-"sleep 1"}
 source .env
 EXTENDED_TOOLS=""
 
-
 if [[ "${EDITION}" == "pro" || "${EDITION}" == "farm" ]]; then
-	if [[ ! $(grep 'docker.bluespice.com' $HOME/.docker/config.json) ]]; then 
+	EXTENDED_TOOLS="${EXTENDED_TOOLS} -f docker-compose.collabpads-service.yml"
+	WIKI_IMAGE=docker.bluespice.com/bluespice/wiki:${VERSION}
+
+	if [[ $(docker images -q ${WIKI_IMAGE}) ]]; then
+		echo "Image ${WIKI_IMAGE} found locally."
+	else if [[ ! $(grep 'docker.bluespice.com' $HOME/.docker/config.json) ]]; then 
 		echo "In order to access our ${EDITION}-Image please login to docker.bluespice.com"
 		docker login docker.bluespice.com
 		if [[ ! $(grep 'docker.bluespice.com' $HOME/.docker/config.json) ]]; then 
@@ -35,8 +39,6 @@ if [[ "${EDITION}" == "pro" || "${EDITION}" == "farm" ]]; then
 		exit
 		fi
 	fi
-	EXTENDED_TOOLS="${EXTENDED_TOOLS} -f docker-compose.collabpads-service.yml"
-	WIKI_IMAGE=docker.bluespice.com/bluespice/wiki:${VERSION}
 else
 	WIKI_IMAGE=bluespice/wiki:${VERSION}
 fi


### PR DESCRIPTION
Customers of PRO and FARM will be able to download the image as TARBALL from bluespice.com, as an alternative to logging into docker.bluespice.com