### PR TITLE
use timezone from host, .env or fallback to UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ If the environment variable `DEV_WIKI_DEBUG` is set, one can set the `debug-entr
 | `KERBEROS`                   | `false`        | enables Kerberos-Authentication                      | Yes      |
 | `BLUESPICE_WIKI_IMAGE`       | ``             | define custom imagepath for wiki-containers          | Yes      |
 | `SERVICES_REPOSITORY_PATH`   | ``             | define custom Services-Repo (mostly for Testing)     | Yes      |
-
+| `TZ`                         | `UTC`          | Timezone for BlueSpice and container system time     | Yes      |

--- a/compose/bluespice-deploy
+++ b/compose/bluespice-deploy
@@ -20,7 +20,10 @@ done
 
 export UPGRADE_ACTION=${UPGRADE_ACTION:-"sleep 1"}
 
+export TZ=$(readlink /etc/localtime 2>/dev/null | sed 's|.*/zoneinfo/||')
+
 source .env
+
 EXTENDED_TOOLS=""
 
 if [[ "${EDITION}" == "pro" || "${EDITION}" == "farm" ]]; then

--- a/compose/docker-compose.main.yml
+++ b/compose/docker-compose.main.yml
@@ -3,6 +3,7 @@ name: bluespice
 x-common-environment: &common-environment
   VERSION: ${VERSION}
   EDITION: ${EDITION}
+  TZ: ${TZ:-UTC}
 
   WIKI_NAME: ${WIKI_NAME}
   WIKI_LANG: ${WIKI_LANG}


### PR DESCRIPTION
This also adds support for setting the timezone via .env file, which overrides the one we detected from the host.