### PR TITLE
Add secrets to wiki-installer

### DIFF
--- a/compose/docker-compose.main.yml
+++ b/compose/docker-compose.main.yml
@@ -48,6 +48,7 @@ services:
     command: start-installer
     volumes:
       - ${DATADIR}/wiki:/data
+    secrets: *common-secrets
 
   wiki-web:
     image: ${BLUESPICE_WIKI_IMAGE}


### PR DESCRIPTION
Without secrets, the container won't start correctly

```
docker logs -f bluespice-wiki-installer
  ____  _            ____        _
 | __ )| |_   _  ___/ ___| _ __ (_) ___ ___
 |  _ \| | | | |/ _ \___ \| '_ \| |/ __/ _ \
 | |_) | | |_| |  __/___) | |_) | | (_|  __/
 |____/|_|\__,_|\___|____/| .__/|_|\___\___|
                          |_|
🚀 BlueSpice free 5.2.1+20260122090752
---------------------------------------------


#############################################
Substitute placeholders in '/app/bin/config/clamd.conf'
###AV_HOST### -> antivirus
###AV_PORT### -> 3310
find: /run/secrets/: No such file or directory
BusyBox v1.37.0 (2025-12-16 14:19:28 UTC) multi-call binary.

Usage: basename FILE [SUFFIX] | -a FILE... | -s SUFFIX FILE...

Strip directory path and SUFFIX from FILE

	-a		All arguments are FILEs
	-s SUFFIX	Remove SUFFIX (implies -a)

```