### PR TITLE
Update docker-compose.ai.yml

### DIFF
--- a/compose/docker-compose.ai.yml
+++ b/compose/docker-compose.ai.yml
@@ -27,6 +27,7 @@ services:
       AI__OLLAMA__URL: ${OLLAMA_URL:-}
       AI__OLLAMA__EMBEDDING_MODEL: ${OLLAMA_EMBEDDING_MODEL:-mxbai-embed-large:335m}
       AI__OLLAMA__MODEL: ${OLLAMA_LLM_MODEL:-llama3.3}
+      AI__ENVIRONMENT: ${AI__ENVIRONMENT:-production}
     secrets:
       - AI__SECURITY__STATIC_API_TOKEN
     volumes:


### PR DESCRIPTION
set default values for AI__ENVIRONMENT in bluespice deploy stack. 
before it was only possible to set it in the docker-compose.override.yml file. now it can be set in the .env file
https://github.com/BlueSpice-Wiki/docker-bluespice-ai?tab=readme-ov-file#available-environment-variables

AI__ENVIRONMENT |	production, development, or 'mock' for dummy responses |	production