### PR TITLE
Fix wire service in kerberos-proxy

### DIFF
--- a/compose/docker-compose.kerberos-proxy.yml
+++ b/compose/docker-compose.kerberos-proxy.yml
@@ -25,11 +25,12 @@ services:
     environment:
       VIRTUAL_HOST: ${WIKI_HOST}
 
-  collabpads:
+  wire:
     environment:
       VIRTUAL_HOST: ${WIKI_HOST}
-      VIRTUAL_PATH: ${WIKI_BASE_PATH:-/}_collabpads/
-      VIRTUAL_PORT: 8081
+      VIRTUAL_PATH: ${WIKI_BASE_PATH:-/}_wire
+      VIRTUAL_PORT: 3333
+      VIRTUAL_DEST: /
 
   diagram:
     environment:


### PR DESCRIPTION
Remove unnecessary collabpads service as well, which blocked free edition installations from using kerberos proxy.

[5.2.x]

ERM47336