### PR TITLE
Replace memcached with valley

### DIFF
--- a/compose/docker-compose.stateless-services.yml
+++ b/compose/docker-compose.stateless-services.yml
@@ -1,7 +1,9 @@
 services:
   cache:
-    image: ${BLUESPICE_SERVICE_REPOSITORY}/cache:${VERSION}
+    image: valkey/valkey:latest
     container_name: ${COMPOSE_PROJECT_NAME:-bluespice}-cache
+    healthcheck:
+      test: redis-cli ping || exit 1
     restart: unless-stopped
   pdf:
     image: ${BLUESPICE_SERVICE_REPOSITORY}/pdf:${VERSION}

--- a/compose/docker-compose.stateless-services.yml
+++ b/compose/docker-compose.stateless-services.yml
@@ -1,10 +1,12 @@
 services:
+
   cache:
     image: valkey/valkey:latest
     container_name: ${COMPOSE_PROJECT_NAME:-bluespice}-cache
     healthcheck:
       test: redis-cli ping || exit 1
     restart: unless-stopped
+    
   pdf:
     image: ${BLUESPICE_SERVICE_REPOSITORY}/pdf:${VERSION}
     container_name: ${COMPOSE_PROJECT_NAME:-bluespice}-pdf


### PR DESCRIPTION
According to semantic-mediawiki recommendations 

see for example:
https://www.semantic-mediawiki.org/wiki/Help:Caching

I think this change should not go into a patch-level release. It would be better suited for 5.3, since we will definitely need updated Docker Compose files if we decide to change the cache type default to Valkey/Redis. 


Some users might only change the `VERSION` in `.env` without updating the Docker Compose files.

We could also "add" `CACHE_TYPE` to the stack so we can make sure a BlueSpice installation does not end up without a working cache.

Also see
https://github.com/hallowelt/docker-bluespice-wiki/pull/109