### PR TITLE
Change MongoDB image version to 8

### DIFF
--- a/compose/docker-compose.collabpads-service.yml
+++ b/compose/docker-compose.collabpads-service.yml
@@ -19,7 +19,7 @@ services:
       VIRTUAL_PORT: 8081
 
   collabpads-database:
-    image: mongo:8.0
+    image: mongo:8
     container_name: ${COMPOSE_PROJECT_NAME:-bluespice}-collabpads-database
     restart: unless-stopped
     healthcheck:

--- a/compose/docker-compose.collabpads-service.yml
+++ b/compose/docker-compose.collabpads-service.yml
@@ -19,7 +19,7 @@ services:
       VIRTUAL_PORT: 8081
 
   collabpads-database:
-    image: mongo:8
+    image: mongo:8.2
     container_name: ${COMPOSE_PROJECT_NAME:-bluespice}-collabpads-database
     restart: unless-stopped
     healthcheck:


### PR DESCRIPTION
I just stumbled across this: the MongoDB container would not start

```bluespice-collabpads-database  | {"t":{"$date":"2026-05-15T12:04:45.286Z"},"s":"F",  "c":"CONTROL",  "id":12257600,"ctx":"main","msg":"MongoDB cannot start: Linux kernel versions 6.19 and newer has a known incompatibility with this version of MongoDB. See https://jira.mongodb.org/browse/SERVER-121912 for more information."}```

Since kernel 6.19 is not that new anymore, we should update our MongoDB image tag.

This commit is also needed for

```
[5.1.x]
[5.2.x}
[5.3.x]
```