### PR TITLE
Add jobqueue (Valkey) to docker-compose

### DIFF
--- a/compose/docker-compose.persistent-data-services.yml
+++ b/compose/docker-compose.persistent-data-services.yml
@@ -12,6 +12,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+      
   database:
     image: ${BLUESPICE_SERVICE_REPOSITORY}/database:${VERSION}
     container_name: ${COMPOSE_PROJECT_NAME:-bluespice}-database
@@ -30,6 +31,16 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+
+  jobqueue:
+    image: ${BLUESPICE_SERVICE_REPOSITORY}/keyvaluestore:${VERSION}
+    container_name: ${COMPOSE_PROJECT_NAME:-bluespice}-jobqueue
+    healthcheck:
+      test: redis-cli ping || exit 1
+    volumes:
+      - ${DATADIR}/keyvaluestore:/data
+    restart: unless-stopped
+    command: valkey-server /etc/valkey/valkey.conf
 
   wiki-installer:
     depends_on:


### PR DESCRIPTION
For the wiki to use it, it currently needs the environment variables.
```
JOBQUEUE_HOST=`jobqueue`  
JOBQUEUE_PORT=`6379`         
```

see https://github.com/hallowelt/docker-bluespice-wiki/commit/121f6fbb71e26c56fcdd0949aa1f0e498acbb811