### PR TITLE
Add MCP url variable to AI service

### DIFF
--- a/compose/docker-compose.ai.yml
+++ b/compose/docker-compose.ai.yml
@@ -28,6 +28,7 @@ services:
       AI__OLLAMA__EMBEDDING_MODEL: ${OLLAMA_EMBEDDING_MODEL:-mxbai-embed-large:335m}
       AI__OLLAMA__MODEL: ${OLLAMA_LLM_MODEL:-llama3.3}
       AI__ENVIRONMENT: ${AI__ENVIRONMENT:-production}
+      AI__MCP__URL: http://mcp:4000/mcp
     secrets:
       - AI__SECURITY__STATIC_API_TOKEN
     volumes:


### PR DESCRIPTION
Since the MCP service is always instantiated in the docker compose, the URL should be automatically passed.

Question for someone more knowledgeable than I am: Will the port 4000 always stay the same, is there a way to map the variable incase it changes?