### PR TITLE
Fix proxied virtual path of mcp and prompt

### DIFF
--- a/compose/docker-compose.ai.yml
+++ b/compose/docker-compose.ai.yml
@@ -64,7 +64,7 @@ services:
       PROMPT_WIKI_BASE_PATH: http://wiki-web:9090
       PROMPT_BRIDGE_URL: http://chat:3000
       VIRTUAL_HOST: ${WIKI_HOST}
-      VIRTUAL_PATH: /_prompt
+      VIRTUAL_PATH: /_prompt/
       VIRTUAL_PORT: 3336
       VIRTUAL_DEST: /
     secrets:
@@ -81,7 +81,7 @@ services:
     environment:
       MCP_WIKI_BASE_PATH: http://wiki-web:9090
       VIRTUAL_HOST: ${WIKI_HOST}
-      VIRTUAL_PATH: /_mcp
+      VIRTUAL_PATH: /_mcp/
       VIRTUAL_PORT: 4000
       VIRTUAL_DEST: /
     restart: unless-stopped


### PR DESCRIPTION
https://{$WIKI_HOST}/_mcp/mcp/ping should be redirected to http://mcp:4000/mcp/ping - `curl -I -X POST` for both links should yield same 200 OK

[5.x]