### PR TITLE
WIRE_LOG_LEVEL should not be debug by default

### DIFF
--- a/compose/docker-compose.stateless-services.yml
+++ b/compose/docker-compose.stateless-services.yml
@@ -22,7 +22,7 @@ services:
     container_name: ${COMPOSE_PROJECT_NAME:-bluespice}-wire
     image: ${BLUESPICE_SERVICE_REPOSITORY}/wire:${VERSION}
     environment:
-      WIRE_LOG_LEVEL: ${WIRE_LOG_LEVEL:-debug}
+      WIRE_LOG_LEVEL: ${WIRE_LOG_LEVEL:-warning}
       WIRE_WIKI_BASE_PATH: http://wiki-web:9090
     secrets:
       - WIRE_API_KEY


### PR DESCRIPTION
I am not sure why we even have it explicitly mapped here. We don’t do this for any other service.

We could also remove it completely.

The `WIRE_LOG_LEVEL` would then be:

`src/wire.mjs:191:	level:process.env.WIRE_LOG_LEVEL ||'warning',`
see: https://github.com/hallowelt/webservice-wire#env-vars


fixes spaming the log

```
bluespice-wire  | [2026-07-27T11:27:22.724Z] debug: Client disconnected {"user":"Admin"}
bluespice-wire  | [2026-07-27T11:27:22.829Z] debug: Client attempting to connect 
bluespice-wire  | [2026-07-27T11:27:22.853Z] debug: Client connected {"user":"Admin","wikiId":"bluespice"}
```