### PR TITLE
Fix auto generation of mandatory token

### DIFF
--- a/compose/bluespice-deploy
+++ b/compose/bluespice-deploy
@@ -77,7 +77,7 @@ if [ -n "${BLUESPICE_WIKI_IMAGE}" ]; then
 	WIKI_IMAGE=${BLUESPICE_WIKI_IMAGE}
 fi
 
-if [ ! -d ${DATADIR}/.secrets ]; then
+if [ ! -d "${DATADIR}/.secrets" ] || [ ! -f "${DATADIR}/.secrets/INTERNAL_SIMPLESAMLPHP_SESSION_API_TOKEN" ]; then
 	echo "Preparing Secrets for 5.2.x"
 	BLUESPICE_WIKI_IMAGE=${WIKI_IMAGE}	\
 	BLUESPICE_SERVICE_REPOSITORY=${BLUESPICE_SERVICE_REPOSITORY} \


### PR DESCRIPTION
As a new token is required since hallowelt/bluespice-deploy#83 it should be auto generated, so that
existing 5.2 installations won't run into an update blocker

ERM49527

[5.2.x and higher]